### PR TITLE
Required Param country added in contact modify.

### DIFF
--- a/src/APIs/Contacts.php
+++ b/src/APIs/Contacts.php
@@ -67,7 +67,8 @@ class Contacts
         $address3 = '',
         $state = '',
         $faxCC = '',
-        $fax = ''
+        $fax = '',
+        $country=''
     )
     {
         return $this->post(
@@ -87,6 +88,7 @@ class Contacts
                 'state'          => $state,
                 'fax-cc'         => $faxCC,
                 'fax'            => $fax,
+                'country'        => $country,
             ]
         );
     }


### PR DESCRIPTION
Need to pass country code every time when trying to edit contact via API. However You can't change Country using API method due to `compliance reasons, the contact country can not be modified using api method` .