### PR TITLE
New ResellerClub constructor argument: source IP address

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,12 @@ Many thanks to [Ahmet Bora](https://github.com/afbora "Ahmet Bora"). This reposi
 # Usage
 Note: All functions return raw response from ResellerClubs's API. (This will change in the future)
 ```
-$resellerClub = new \habil\ResellerClub\ResellerClub('<userId>', '<apiKey>', true, 60.0); // Last arguments are for testMode and timeout of the request in seconds.
+// string $userId
+// string $apiKey
+// boolean $testMode Default is false.
+// float $timeout Timeout of the request in seconds. Default is 0 (wait indefinitely)
+// string $bindIp Source IP address for Guzzle connections (CURLOPT_INTERFACE and socket context option bindto). Default is '0' which means let the system choose the IP.
+$resellerClub = new \habil\ResellerClub\ResellerClub('<userId>', '<apiKey>', true, 60.0, '127.0.0.1');
 
 // Get Available TLDs
 $resellerClub->domains()->getTLDs();

--- a/src/ResellerClub.php
+++ b/src/ResellerClub.php
@@ -30,7 +30,7 @@ class ResellerClub
      */
     private $authentication = [];
 
-    public function __construct($userId, $apiKey, $testMode = FALSE, $timeout = 0)
+    public function __construct($userId, $apiKey, $testMode = FALSE, $timeout = 0, $bindIp = '0')
     {
         $this->authentication = [
             'auth-userid' => $userId,
@@ -46,6 +46,14 @@ class ResellerClub
                 'verify'   => FALSE,
                 'connect_timeout' => (float)$timeout,
                 'timeout' => (float)$timeout,
+                'curl' => [
+                    CURLOPT_INTERFACE => null !== $bindIp ? $bindIp : '0',
+                ],
+                'stream_context' => [
+                    'socket' => [
+                        'bindto' => null !== $bindIp ? $bindIp : '0',
+                    ]
+                ],
             ]
         );
     }


### PR DESCRIPTION
Source IP address for Guzzle connections (CURLOPT_INTERFACE and socket context option bindto).
Default is '0' which means let the system choose the IP.