### PR TITLE
Add ability to skip IRPT on contact modification

### DIFF
--- a/src/APIs/Domains.php
+++ b/src/APIs/Domains.php
@@ -605,18 +605,22 @@ class Domains
         $regContactId,
         $adminContactId,
         $techContactId,
-        $billingContactId
+        $billingContactId,
+        $skipIRTP = false
     ) {
-        return $this->post(
-            'modify-contact',
-            [
-                'order-id'           => $orderId,
-                'reg-contact-id'     => $regContactId,
-                'admin-contact-id'   => $adminContactId,
-                'tech-contact-id'    => $techContactId,
-                'billing-contact-id' => $billingContactId,
-            ]
-        );
+        $params = [
+            'order-id'           => $orderId,
+            'reg-contact-id'     => $regContactId,
+            'admin-contact-id'   => $adminContactId,
+            'tech-contact-id'    => $techContactId,
+            'billing-contact-id' => $billingContactId,
+        ];
+
+        if ($skipIRTP) {
+            $params = array_merge($params, $this->processAttributes(['skipIRTP' => 'true']));
+        }
+
+        return $this->post('modify-contact', $params);
     }
 
     /**


### PR DESCRIPTION
Since this API call has only one extra parameter I made it as a boolean. @see https://manage.logicboxes.com/kb/node/777

I've tried it on my sandbox account, the request itself was formed correctly, but their API returned:
```
{
    "status": "ERROR",
    "message": "You are not allowed to perform this action"
}
```
 
So I've contacted their support and they raised a ticket. Once the ResellerClub devs give us a response, I will merge this PR.

```
Hello,

I am escalating this issue to the concerned team.
We will check and update you on the same ticket.
Your patience is highly appreciated in the interim.

Thanks and regards,
Anagha.N


Ticket Details
Ticket ID: SGV-278-40173
Department: API
Type: Issue
```