### PR TITLE
Fix suggest domain name endpoint

### DIFF
--- a/src/APIs/Domains.php
+++ b/src/APIs/Domains.php
@@ -4,7 +4,6 @@ namespace habil\ResellerClub\APIs;
 
 use Exception;
 use habil\ResellerClub\Helper;
-use SimpleXMLElement;
 
 /**
  * Class Domains
@@ -156,22 +155,23 @@ class Domains
     }
 
     /**
+     * @see https://manage.logicboxes.com/kb/node/1085
+     *
      * @param string $keyword
-     * @param string $tld
+     * @param array  $tld
      * @param bool   $exactMatch
      *
      * @return array|Exception
      * @throws Exception
-     * @link     https://manage.logicboxes.com/kb/node/1085
      */
-    public function suggestNames($keyword, $tld = '', $exactMatch = false)
+    public function suggestNames($keyword, $tld = [], $exactMatch = false)
     {
         return $this->get(
             'suggest-names',
             [
                 'keyword'     => $keyword,
-                'tld'         => $tld,
-                'exact-match' => $exactMatch,
+                'tld-only'    => $tld,
+                'exact-match' => $exactMatch ? 'true' : 'false',
             ],
             'v5/'
         );


### PR DESCRIPTION
The documentation seems to be outdated (https://manage.logicboxes.com/kb/node/1085). 

Tried sending `tld-only` param as a string, but it doesn't do anything, once I've changed it to an array, it started working.

Also, all `Boolean` params should be sent as a string like `false` or `true` (https://manage.logicboxes.com/kb/answer/755#bool). 🤷  